### PR TITLE
Realdev.11 redundancy

### DIFF
--- a/events/roci_realdev_events.txt
+++ b/events/roci_realdev_events.txt
@@ -1335,6 +1335,18 @@ planet_event = {
 			}
 		}
 		else = {
+			set_variable = { which = realdev_planet_build_speed value = realdev_industry }
+			multiply_variable = { which = realdev_planet_build_speed value = realdev_industry_construction_ratio }
+			
+			set_variable = { which = realdev_industry_assembly_ratio value = 1 }
+			subtract_variable = { which = realdev_industry_assembly_ratio value = realdev_industry_construction_ratio }
+			
+			set_variable = { which = realdev_assembly_speed value = realdev_industry }
+			multiply_variable = { which = realdev_assembly_speed value = realdev_industry_assembly_ratio }
+			
+			round_variable = realdev_planet_build_speed
+			round_variable = realdev_assembly_speed
+
 			if = {
 				limit = {
 					OR = {
@@ -1342,17 +1354,6 @@ planet_event = {
 						bonus_production_active = yes
 					}
 				}
-				set_variable = { which = realdev_planet_build_speed value = realdev_industry }
-				multiply_variable = { which = realdev_planet_build_speed value = realdev_industry_construction_ratio }
-				
-				set_variable = { which = realdev_industry_assembly_ratio value = 1 }
-				subtract_variable = { which = realdev_industry_assembly_ratio value = realdev_industry_construction_ratio }
-				
-				set_variable = { which = realdev_assembly_speed value = realdev_industry }
-				multiply_variable = { which = realdev_assembly_speed value = realdev_industry_assembly_ratio }
-				
-				round_variable = realdev_planet_build_speed
-				round_variable = realdev_assembly_speed
 				
 				if = {
 					limit = {
@@ -1364,18 +1365,6 @@ planet_event = {
 				}
 			}
 			else = {
-				set_variable = { which = realdev_planet_build_speed value = realdev_industry }
-				multiply_variable = { which = realdev_planet_build_speed value = realdev_industry_construction_ratio }
-				
-				set_variable = { which = realdev_industry_assembly_ratio value = 1 }
-				subtract_variable = { which = realdev_industry_assembly_ratio value = realdev_industry_construction_ratio }
-				
-				set_variable = { which = realdev_assembly_speed value = realdev_industry }
-				multiply_variable = { which = realdev_assembly_speed value = realdev_industry_assembly_ratio }
-				
-				round_variable = realdev_planet_build_speed
-				round_variable = realdev_assembly_speed
-				
 				change_variable = { which = realdev_country_industry value = realdev_assembly_speed }
 				set_variable = { which = realdev_assembly_speed value = 0 }
 			}

--- a/events/roci_realdev_events.txt
+++ b/events/roci_realdev_events.txt
@@ -1353,16 +1353,11 @@ planet_event = {
 						can_pops_assemble_on_planet = yes
 						bonus_production_active = yes
 					}
+					check_variable = { which = realdev_assembly_speed value > realdev_assembly_cap }
 				}
-				
-				if = {
-					limit = {
-						check_variable = { which = realdev_assembly_speed value > realdev_assembly_cap }
-					}
-					subtract_variable = { which = realdev_assembly_speed value = realdev_assembly_cap }
-					change_variable = { which = realdev_country_industry value = realdev_assembly_speed }
-					set_variable = { which = realdev_assembly_speed value = realdev_assembly_cap }
-				}
+				subtract_variable = { which = realdev_assembly_speed value = realdev_assembly_cap }
+				change_variable = { which = realdev_country_industry value = realdev_assembly_speed }
+				set_variable = { which = realdev_assembly_speed value = realdev_assembly_cap }
 			}
 			else = {
 				change_variable = { which = realdev_country_industry value = realdev_assembly_speed }


### PR DESCRIPTION
My first time reading and modifying code for the Clausewitz Engine, so keeping it simple.
Separated the changes into discrete commits.
Extracts repeated code, and collapses a nested if.

If I'm interpreting this correctly:
When a planet is building and has bonus_production and `can_pops_assemble_on_planet = no` and `realdev_assembly_speed < cap` then:     `realdev_assembly_speed` does not receive any `assembly_speed` even though it should? (Bug?)
It's 11:53PM here and my brain feels like a fried egg so I'm not confident in my interpretation.